### PR TITLE
added localkube powered integration test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,12 @@
 language: go
-sudo: false
+sudo: required
 go:
   - 1.6
 
 go_import_path: rsprd.com/spread
+
+services:
+  - docker
 
 install:
   # install build dependencies

--- a/Makefile
+++ b/Makefile
@@ -38,7 +38,7 @@ GOX_ARCH ?= amd64
 all: clean validate test
 
 .PHONY: release
-release: validate test integration crossbuild
+release: validate test crossbuild
 
 .PHONY: test
 test: unit integration
@@ -56,8 +56,10 @@ integration: build
 validate: lint checkgofmt vet
 
 .PHONY: build
-build:
-	$(GO) build $(GOBUILD_FLAGS) $(GOBUILD_LDFLAGS) $(EXEC_PKG)
+build: build/spread
+
+build/spread:
+	$(GO) build $(GOBUILD_FLAGS) $(GOBUILD_LDFLAGS) -o $@ $(EXEC_PKG)
 
 build/spread-linux-static:
 	GOOS=linux $(GO) build -o $@ $(GOBUILD_FLAGS) $(STATIC_LDFLAGS) $(EXEC_PKG)

--- a/Makefile
+++ b/Makefile
@@ -38,11 +38,16 @@ GOX_ARCH ?= amd64
 all: clean validate test
 
 .PHONY: release
-release: validate test crossbuild
+release: validate test integration crossbuild
 
 .PHONY: test
 test: build
 	$(GO) test $(GOTEST_FLAGS) $(PKGS)
+
+.PHONY: integration
+integration:
+	mkdir -p ./build
+	./test/mattermost-demo.sh
 
 .PHONY: validate
 validate: lint checkgofmt vet

--- a/Makefile
+++ b/Makefile
@@ -41,11 +41,14 @@ all: clean validate test
 release: validate test integration crossbuild
 
 .PHONY: test
-test: build
+test: unit integration
+
+.PHONY: unit
+unit: build
 	$(GO) test $(GOTEST_FLAGS) $(PKGS)
 
 .PHONY: integration
-integration:
+integration: build
 	mkdir -p ./build
 	./test/mattermost-demo.sh
 

--- a/test/mattermost-demo.sh
+++ b/test/mattermost-demo.sh
@@ -1,0 +1,48 @@
+#!/bin/sh
+set -e
+
+NODE_IP="127.0.0.1"
+
+function retry() {
+    COMMAND=$1
+    RETRIES=5
+
+    # override default if retry count is set
+    if [ -n "$2" ]; then
+        RETRIES=$2
+    fi
+
+    for i in {1..$RETRIES}; do eval "$COMMAND" && return || sleep 1; done
+    echo "Failed to: $1"
+    exit 1
+}
+
+KUBECTL="./build/kubectl"
+MATTERMOST="./build/mattermost"
+export PATH="./build:$PATH"
+
+if [ ! -f $KUBECTL ]; then
+    echo "Installing kubectl..."
+    curl -o $KUBECTL https://storage.googleapis.com/kubernetes-release/release/v1.2.1/bin/linux/amd64/kubectl
+    chmod +x $KUBECTL
+fi
+
+echo "Starting up localkube server"
+spread cluster start
+
+if [ ! -d "$MATTERMOST" ]; then
+    echo "Cloning mattermost deployment repo"
+    git clone http://github.com/redspread/kube-mattermost $MATTERMOST
+fi
+
+echo "Deploying demo..."
+retry "spread deploy $MATTERMOST"
+
+echo "Checking if service had been created"
+retry "kubectl get services/mattermost-app"
+
+echo "Getting node port..."
+NODE_PORT=$(kubectl get services/mattermost-app --template='{{range .spec.ports}}{{printf "%g" .nodePort}}{{end}}')
+
+echo "Checking if started app successfully"
+retry "curl --fail http://$NODE_IP:$NODE_PORT" 10


### PR DESCRIPTION
Spins up cluster using the freshly build binary of spread, pull the latest mattermost demo, deploys it to [localkube](https://github.com/redspread/localkube), connects to mattermost app server to confirm everything is working.

Closes #50

Good example of usage for #42 and redspread/localkube#26.