### PR TITLE
add go15 requirement to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,9 +32,10 @@ See our [philosophy](./philosophy.md) for more on our mission and values.
 
 **Linux/Windows**
 
-Make sure Go and Git are installed.
+Make sure Go 1.5+ and Git are installed.
 
-`go get rsprd.com/spread/cmd/spread`
+Run:
+`GO15VENDOREXPERIMENT=1 go get rsprd.com/spread/cmd/spread`
 
 ##Quickstart
 


### PR DESCRIPTION
also added `GO15VENDOREXPERIMENT=1` to directions to ensure Go vendoring is enabled.