### PR TITLE
gofmt -s -w

### DIFF
--- a/cli/cluster.go
+++ b/cli/cluster.go
@@ -6,9 +6,7 @@ import (
 	"github.com/codegangsta/cli"
 )
 
-
 // Cluster manages the localkube Kubernetes development environment.
 func (s SpreadCli) Cluster() *cli.Command {
 	return localkubectl.Command(s.out)
 }
-


### PR DESCRIPTION
`make` wouldn't run successfully without this file being formatted.

I'm not sure how the previous travis run passed, because when I run `make validate`, I get:

```
± make validate
for pkg in ./pkg/... ./cli/... ./cmd/...; do \
		echo "Running golint on $i:"; \
		golint $i; \
	done;
Running golint on :
Running golint on :
Running golint on :
# get all go files and run go fmt on them
files=$(find . -name '*.go' -not -path "./vendor/*" | xargs gofmt  -l); if [[ -n "$files" ]]; then \
		  echo "Error: 'gofmt ' needs to be run on:"; \
		  echo "${files}"; \
		  exit 1; \
		  fi;
Error: 'gofmt ' needs to be run on:
./cli/cluster.go
make: *** [checkgofmt] Error 1
```