### PR TITLE
Make Makefile if-statement dash-compatible

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -89,8 +89,8 @@ vet:
 
 lint: .golint-install
 	for pkg in $(PKGS); do \
-		echo "Running golint on $$i:"; \
-		golint $$i; \
+		echo "Running golint on $$pkg:"; \
+		golint $$pkg; \
 	done;
 
 .PHONY: checkgofmt

--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ lint: .golint-install
 .PHONY: checkgofmt
 checkgofmt:
 	# get all go files and run go fmt on them
-	files=$$($(GOFILES) | xargs $(GOFMT) -l); if [[ -n "$$files" ]]; then \
+	files=$$($(GOFILES) | xargs $(GOFMT) -l); if [ -n "$$files" ]; then \
 		  echo "Error: '$(GOFMT)' needs to be run on:"; \
 		  echo "$${files}"; \
 		  exit 1; \

--- a/Makefile
+++ b/Makefile
@@ -85,7 +85,7 @@ build-gitlab: build/spread-linux-static
 
 .PHONY: vet
 vet:
-	$(GO) vet $(PKGS) 
+	$(GO) vet $(PKGS)
 
 lint: .golint-install
 	for pkg in $(PKGS); do \
@@ -117,7 +117,7 @@ gox-setup: .gox-install
 .PHONY: clean
 clean:
 	rm -vf .gox-* .golint-*
-	rm -rfv ./build 
+	rm -rfv ./build
 	$(GO) clean $(PKGS) || true
 
 .PHONY: godep


### PR DESCRIPTION
Also miscellaneous other Makefile tidying.

Closes https://github.com/redspread/spread/issues/135

So now with make validate we get the following, though it exits with a exit code of 2 if it fails, though we're exiting with exit 1, which I think is because Makefile exits with a 2 if a job fails or errors, but I think that is okay.

```
# get all go files and run go fmt on them
files=$(find . -name '*.go' -not -path "./vendor/*" | xargs gofmt  -l); if [ -n "$files" ]; then \
      echo "Error: 'gofmt ' needs to be run on:"; \
      echo "${files}"; \
      exit 1; \
      fi;
Error: 'gofmt ' needs to be run on:
./cli/cluster.go
Makefile:98: recipe for target 'checkgofmt' failed
make: *** [checkgofmt] Error 1
root@a8f896da1575:/usr/src/myapp# echo $?
2
```

This also fixes `golint`ing, which was using the wrong variable in the for-loop, so now it correctly prints out `golint` errors instead of doing:

```
for pkg in ./pkg/... ./cli/... ./cmd/...; do \
	echo "Running golint on $i:"; \
	golint $i; \
done;
Running golint on :
Running golint on :
Running golint on :
```